### PR TITLE
DAY1-155 Update K8s resource API version

### DIFF
--- a/cron-deployment.yaml
+++ b/cron-deployment.yaml
@@ -1,5 +1,5 @@
 #apiVersion: batch/v1beta1
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello
@@ -16,7 +16,8 @@ spec:
             - /bin/sh
             - -c
             - date; echo Hello from the Kubernetes cluster
-            image: gcr.io/google-containers/busybox@sha256:545e6a6310a27636260920bc07b994a299b6708a1b26910cfefd335fdfb60d2b
-            
-          
-          
+            image: 
+              gcr.io/google-containers/busybox@sha256:545e6a6310a27636260920bc07b994a299b6708a1b26910cfefd335fdfb60d2b
+
+
+


### PR DESCRIPTION
This pull request updates the API version from `batch/v1beta1` to `batch/v1` for `CronJob`